### PR TITLE
docs(drive): Update formatting and add test content in About Drive page

### DIFF
--- a/fern/products/drive/overview/about_drive.mdx
+++ b/fern/products/drive/overview/about_drive.mdx
@@ -1,5 +1,3 @@
-
-
 # About DoorDash Drive
 
 Drive API Production Access is Limited
@@ -10,29 +8,36 @@ Production permissions to the Drive API is currently restricted, and we cannot p
 
 DoorDash Drive enables you to use DoorDash's on-demand logistics platform and fleet of Dashers to deliver your goods quickly and easily, without the hassle of staffing your own delivery fleet. Whether you need flexible fulfillment for overflow or a consistent on-demand delivery service, our platform is designed to work with your business.
 
-## Get started [#get-started]
+Hey this is deep!!
+
+## Get started \[#get-started]
 
 Jump in today and start developing an app that uses the Drive API!
 
 * If your app will be for restaurants, use our [How to Build for Restaurants Guide](https://developer.doordash.com/en-US/docs/drive/how_to/build_for_restaurants/)
+
 * If your app will be in Node.js, use our [Get started (Node.js SDK) tutorial](/en-US/docs/drive/tutorials/get_started_sdk)
+
 * If your app will be in any other language, use our [Get started (API) tutorial](/en-US/docs/drive/tutorials/get_started)
 
 API: Drive
 
-This doc covers the Drive API. If you're using the Drive (classic) API, use the [Drive (classic) docs instead](/en-US/docs/drive_classic/overview/about_drive_classic).  
-  
+This doc covers the Drive API. If you're using the Drive (classic) API, use the [Drive (classic) docs instead](/en-US/docs/drive_classic/overview/about_drive_classic).
+
 You can tell which API you're using by checking the URL. If your API URL contains "v2", like `https://openapi.doordash.com/drive`/**v2**/`quotes`, you're using the Drive API.
 
-## Integration process overview [#integration-process-overview]
+## Integration process overview \[#integration-process-overview]
 
 Here's what you can expect for the integration process:
 
 1. You'll [generate an access key](/en-US/docs/drive/how_to/manage_credentials) which will allow you to access our sandbox environment.
+
 2. You'll use the [delivery simulator](/en-US/docs/drive/how_to/use_delivery_simulator) and API documentation to build your integration. The development timeline is entirely up to your team's own roadmap. We're here to [support](/en-US/docs/drive/support) you as needed!
+
 3. Once you've completed development and are ready to go live, you'll submit a quick request for [production access](/en-US/docs/drive/how_to/get_production_access).
+
 4. The DoorDash team will review your request and reach out within a few days to schedule a demo of your finished product.
+
 5. The DoorDash team will provide an update ASAP on your approval status. Once approved, you can generate a production key and begin requesting real deliveries immediately.
 
 Use the menu on the left to navigate through our documentation or jump right into the API reference using the menu in the top-right corner. Happy building!
-


### PR DESCRIPTION

This PR makes several formatting changes to the About Drive documentation page:
- Fixes markdown formatting for headers and lists
- Adds proper line spacing between list items
- Removes extra blank lines
- Adds a test line "Hey this is deep!!" that should likely be removed before merging
- Escapes square brackets in headers

Note: There appears to be a test/placeholder line "Hey this is deep!!" that was added - this should probably be removed before merging if it's not intended for production.